### PR TITLE
allow docroot to be subdirectory of deploy directory

### DIFF
--- a/providers/mod_php_apache2.rb
+++ b/providers/mod_php_apache2.rb
@@ -47,9 +47,7 @@ action :before_deploy do
 
   new_resource = @new_resource
   apache_docroot = "#{new_resource.application.path}/current"
-  relative_docroot = new_resource.docroot
-  relative_docroot ||= new_resource.application.docroot
-  apache_docroot << "/#{relative_docroot}" if relative_docroot
+  apache_docroot << "/#{new_resource.docroot}" if new_resource.docroot
 
   web_app new_resource.application.name do
     docroot apache_docroot

--- a/providers/mod_php_apache2.rb
+++ b/providers/mod_php_apache2.rb
@@ -46,9 +46,13 @@ end
 action :before_deploy do
 
   new_resource = @new_resource
+  apache_docroot = "#{new_resource.application.path}/current"
+  relative_docroot = new_resource.docroot
+  relative_docroot ||= new_resource.application.docroot
+  apache_docroot << "/#{relative_docroot}" if relative_docroot
 
   web_app new_resource.application.name do
-    docroot "#{new_resource.application.path}/current"
+    docroot apache_docroot
     template new_resource.webapp_template || 'php.conf.erb'
     cookbook new_resource.webapp_template ? new_resource.cookbook_name : "application_php"
     server_name "#{new_resource.application.name}.#{node['domain']}"

--- a/providers/php.rb
+++ b/providers/php.rb
@@ -64,6 +64,8 @@ end
 
 def create_settings_file
   host = new_resource.find_database_server(new_resource.database_master_role)
+  relative_docroot = new_resource.docroot
+  relative_docroot ||= new_resource.application.docroot
 
   template "#{new_resource.path}/shared/#{new_resource.local_settings_file_name}" do
     source new_resource.settings_template || "#{new_resource.local_settings_file_name}.erb"
@@ -72,6 +74,7 @@ def create_settings_file
     mode "644"
     variables(
       :path => "#{new_resource.path}/current",
+      :docroot => relative_docroot,
       :host => host,
       :database => new_resource.database
     )

--- a/resources/mod_php_apache2.rb
+++ b/resources/mod_php_apache2.rb
@@ -22,3 +22,5 @@ include Chef::Resource::ApplicationBase
 attribute :server_aliases, :kind_of => [Array, NilClass], :default => nil
 # Actually defaults to "php.conf.erb", but nil means it wasn't set by the user
 attribute :webapp_template, :kind_of => [String, NilClass], :default => nil
+# docroot: set when the http docroot is a subdir of the deployed app
+attribute :docroot, :kind_of => [String, NilClass], :default => nil

--- a/resources/php.rb
+++ b/resources/php.rb
@@ -24,6 +24,8 @@ attribute :local_settings_file, :kind_of => [String, NilClass], :default => 'Loc
 # Actually defaults to "#{local_settings_file_name}.erb", but nil means it wasn't set by the user
 attribute :settings_template, :kind_of => [String, NilClass], :default => nil
 attribute :packages, :kind_of => [Array, Hash], :default => []
+# docroot: set when the http docroot is a subdir of the deployed app
+attribute :docroot, :kind_of => [String, NilClass], :default => nil
 
 def local_settings_file_name
   @local_settings_file_name ||= local_settings_file.split(/[\\\/]/).last


### PR DESCRIPTION
Adds a docroot attribute that the application_xxx cookbooks can use when the http docroot for an app is a subdir of the deployed app.

in combination with https://github.com/opscode-cookbooks/application/pull/17 fixes http://tickets.opscode.com/browse/COOK-1487
