### PR TITLE
[COOK-1784] Allow symlink_before_migrate for local_settings_file

### DIFF
--- a/providers/php.rb
+++ b/providers/php.rb
@@ -25,10 +25,7 @@ action :before_compile do
 
   new_resource.local_settings_file 'LocalSettings.php' unless new_resource.local_settings_file
 
-  new_resource.symlink_before_migrate.update({
-    new_resource.local_settings_file_name => new_resource.local_settings_file
-  })
-
+  new_resource.symlink_before_migrate[new_resource.local_settings_file_name] ||= new_resource.local_settings_file
 end
 
 action :before_deploy do


### PR DESCRIPTION
See ticket in opscode jira, but briefly the recipe configuring the resource should be allowed to symink the settings file to wherever they want, before migrate or otherwise.
