### PR TITLE
Add required dependency with application cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,5 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.4"
 
 depends "apache2"
+depends "application"
 depends "php"


### PR DESCRIPTION
`application` cookbook is a required dependency since php resource include  `include Chef::Resource::ApplicationBase` which is provided by `application` cookbook
