### PR TITLE
[COOK-2510] Change app_root to mod_php_apache2 resource attribute.

### DIFF
--- a/resources/mod_php_apache2.rb
+++ b/resources/mod_php_apache2.rb
@@ -22,3 +22,4 @@ include Chef::Resource::ApplicationBase
 attribute :server_aliases, :kind_of => [Array, NilClass], :default => nil
 # Actually defaults to "php.conf.erb", but nil means it wasn't set by the user
 attribute :webapp_template, :kind_of => [String, NilClass], :default => nil
+attribute :app_root, :kind_of => String, :default => "/"

--- a/resources/php.rb
+++ b/resources/php.rb
@@ -24,7 +24,6 @@ attribute :local_settings_file, :kind_of => [String, NilClass], :default => 'Loc
 # Actually defaults to "#{local_settings_file_name}.erb", but nil means it wasn't set by the user
 attribute :settings_template, :kind_of => [String, NilClass], :default => nil
 attribute :packages, :kind_of => [Array, Hash], :default => []
-attribute :app_root, :kind_of => String, :default => "/"
 
 def local_settings_file_name
   @local_settings_file_name ||= local_settings_file.split(/[\\\/]/).last


### PR DESCRIPTION
In http://tickets.opscode.com/browse/COOK-2395 the application_php cookbook was updated to move the app_root attribute out of the application cookbook and into the application_php cookbook. However, the attribute was added to the php resource instead of the mod_php_apache2 resource which calls app_root, this results in a 

```
FATAL: NoMethodError: undefined method `app_root' for Chef::Resource::ApplicationPhpModPhpApache2
```

whenever the cookbook is run with app_root defined.

The fix is to move the app_root attribute into the mod_php_apache2 resource instead of php.
