### PR TITLE
[COOK-3820] Fixed deprecated includes

### DIFF
--- a/providers/mod_php_apache2.rb
+++ b/providers/mod_php_apache2.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 

--- a/providers/php.rb
+++ b/providers/php.rb
@@ -18,7 +18,7 @@
 #
 
 include ApplicationPhpCookbook::ProviderBase
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 def load_current_resource
   if(new_resource.pear_packages.empty? && !new_resource.packages.empty?)


### PR DESCRIPTION
Cleaning up my runs, wanted to contribute fixes for these warnings:
"Chef::Mixin::LanguageIncludeRecipe is deprecated, use Chef::DSL::IncludeRecipe"

https://tickets.opscode.com/browse/COOK-3820
